### PR TITLE
feature/proj-68

### DIFF
--- a/src/features/auth/ui/index.ts
+++ b/src/features/auth/ui/index.ts
@@ -1,0 +1,1 @@
+export * from './sentEmail'

--- a/src/features/auth/ui/sentEmail/index.ts
+++ b/src/features/auth/ui/sentEmail/index.ts
@@ -1,0 +1,1 @@
+export * from './sentEmail'

--- a/src/features/auth/ui/sentEmail/sentEmail.module.scss
+++ b/src/features/auth/ui/sentEmail/sentEmail.module.scss
@@ -38,7 +38,7 @@
   button {
     @include media($mobile-width) {
       width: 100%;
-      height: 48px;
+      padding: 12px 0;
     }
   }
 }

--- a/src/features/auth/ui/sentEmail/sentEmail.module.scss
+++ b/src/features/auth/ui/sentEmail/sentEmail.module.scss
@@ -1,0 +1,64 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 0 24px 36px;
+
+  @media (width <= 360px) {
+    padding: 0 12px 30px;
+  }
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 30px;
+
+  @media (width <= 360px) {
+    padding: 12px;
+  }
+}
+
+.content {
+  width: 100%;
+  max-width: 380px;
+
+  @media (width <= 768px) {
+    width: 100%;
+    max-width: 330px;
+    height: 240px;
+  }
+}
+
+.footer {
+  display: flex;
+  justify-content: end;
+
+  button {
+    @media (width <= 360px) {
+      width: 100%;
+      height: 48px;
+    }
+  }
+}
+
+.description {
+  @media (width <= 360px) {
+    width: 306px;
+    margin: 0 auto;
+    text-align: center;
+  }
+}
+
+.icon {
+  width: var(--svg-size);
+  height: var(--svg-size);
+
+  &:hover {
+    color: var(--light-900);
+  }
+
+  &:active {
+    color: var(--light-100);
+  }
+}

--- a/src/features/auth/ui/sentEmail/sentEmail.module.scss
+++ b/src/features/auth/ui/sentEmail/sentEmail.module.scss
@@ -1,10 +1,13 @@
+@import 'src/shared/styles/mixins';
+@import 'src/shared/styles/variables';
+
 .container {
   display: flex;
   flex-direction: column;
   gap: 18px;
   padding: 0 24px 36px;
 
-  @media (width <= 360px) {
+  @include media($mobile-width) {
     padding: 0 12px 30px;
   }
 }
@@ -14,7 +17,7 @@
   justify-content: space-between;
   margin-bottom: 30px;
 
-  @media (width <= 360px) {
+  @include media($mobile-width) {
     padding: 12px;
   }
 }
@@ -23,10 +26,8 @@
   width: 100%;
   max-width: 380px;
 
-  @media (width <= 768px) {
-    width: 100%;
+  @include media($mobile-width) {
     max-width: 330px;
-    height: 240px;
   }
 }
 
@@ -35,7 +36,7 @@
   justify-content: end;
 
   button {
-    @media (width <= 360px) {
+    @include media($mobile-width) {
       width: 100%;
       height: 48px;
     }
@@ -43,14 +44,15 @@
 }
 
 .description {
-  @media (width <= 360px) {
-    width: 306px;
+  @include media($mobile-width) {
+    max-width: 306px;
     margin: 0 auto;
     text-align: center;
   }
 }
 
 .icon {
+  cursor: pointer;
   width: var(--svg-size);
   height: var(--svg-size);
 

--- a/src/features/auth/ui/sentEmail/sentEmail.tsx
+++ b/src/features/auth/ui/sentEmail/sentEmail.tsx
@@ -26,8 +26,6 @@ export const SentEmail = ({ email }: SentEmailProps) => {
 
   const finalEmail = email ?? 'epam@epam.com'
 
-  const onClickHandler = () => {}
-
   return (
     <Modal open>
       <ModalContent className={classNames.content}>
@@ -42,7 +40,9 @@ export const SentEmail = ({ email }: SentEmailProps) => {
             We have sent a link to confirm your email to {finalEmail}
           </Typography>
           <ModalFooter className={classNames.footer}>
-            <Button onClick={onClickHandler}>OK</Button>
+            <ModalClose>
+              <Button>OK</Button>
+            </ModalClose>
           </ModalFooter>
         </div>
       </ModalContent>

--- a/src/features/auth/ui/sentEmail/sentEmail.tsx
+++ b/src/features/auth/ui/sentEmail/sentEmail.tsx
@@ -1,0 +1,51 @@
+import { CloseOutline } from '@/assets'
+import {
+  Button,
+  Modal,
+  ModalClose,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  Typography,
+} from '@photo-fiesta/ui-lib'
+
+import styles from './sentEmail.module.scss'
+
+export type SentEmailProps = {
+  email?: string
+}
+export const SentEmail = ({ email }: SentEmailProps) => {
+  const classNames = {
+    container: styles.container,
+    content: styles.content,
+    description: styles.description,
+    footer: styles.footer,
+    header: styles.header,
+    icon: styles.icon,
+  } as const
+
+  const finalEmail = email ?? 'epam@epam.com'
+
+  const onClickHandler = () => {}
+
+  return (
+    <Modal open>
+      <ModalContent className={classNames.content}>
+        <ModalHeader className={classNames.header}>
+          <Typography variant={'h1'}>Email sent</Typography>
+          <ModalClose>
+            <CloseOutline className={classNames.icon} />
+          </ModalClose>
+        </ModalHeader>
+        <div className={classNames.container}>
+          <Typography className={classNames.description} variant={'text16'}>
+            We have sent a link to confirm your email to {finalEmail}
+          </Typography>
+          <ModalFooter className={classNames.footer}>
+            <Button onClick={onClickHandler}>OK</Button>
+          </ModalFooter>
+        </div>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,9 +1,11 @@
+import { SentEmail } from '@/features/auth/ui'
 import { Modal } from '@photo-fiesta/ui-lib'
 
 export default function Home() {
   return (
     <>
       <Modal />
+      <SentEmail />
     </>
   )
 }

--- a/src/shared/styles/_mixins.scss
+++ b/src/shared/styles/_mixins.scss
@@ -26,3 +26,9 @@
   font-weight: $weight;
   line-height: $line-height;
 }
+
+@mixin media($width) {
+  @media (max-width: $width) {
+    @content;
+  }
+}

--- a/src/shared/styles/_variables.scss
+++ b/src/shared/styles/_variables.scss
@@ -1,5 +1,1 @@
-:root {
-  /* stylelint-disable-next-line scss/double-slash-comment-whitespace-inside */
-  //todo: remove this, it's just for testing
-  --global-variable: 10px;
-}
+$mobile-width: 360px;


### PR DESCRIPTION
# Pull Request: SentEmail Component

## Description

This pull request introduces the `SentEmail` component, which displays a confirmation message in a modal when an email link is sent to the user. The component is designed to be responsive, ensuring proper display on both desktop and mobile devices.

## Component Overview

### Props
- **`email?`**: (optional) The email address to which the confirmation link is sent. If not provided, it defaults to `epam@epam.com`.

### Structure
- **`Modal`**: The parent component that controls the visibility of the modal.
- **`ModalHeader`**: Contains the title and close button of the modal.
- **`ModalContent`**: Wraps the main content of the modal.
- **`Typography`**: Used for text display, including the title and email confirmation message.
- **`ModalFooter`**: Contains the `OK` button that closes the modal.
- **`Button`**: The action button used for closing the modal.
- **`CloseOutline`**: An icon component used to close the modal.

## Styling

### General Styles
- **Container**: Displays content in a column layout with a gap of `18px` and padding of `0 24px 36px`.
- **Header**: Flexbox layout to space out the title and close icon, with a bottom margin of `30px`.
- **Content**: The modal's content area, with a maximum width of `380px`.
- **Footer**: Aligns the button to the right.
- **Icon**: Sizes the close icon and changes its color on hover and active states.

### Responsive Design
Media queries have been added to ensure proper display on smaller screens:
- **`@media (width <= 768px)`**: 
  - Adjusts the `content` width to `330px` and height to `240px`.
- **`@media (width <= 360px)`**:
  - Adjusts `container` padding to `12px 30px`.
  - Centers the `description` text with a width of `306px`.
  - Adds padding to the `header`.
  - Expands the `button` to full width with a height of `48px`.

## Screenshots

### Desktop View
![Desktop View](https://github.com/user-attachments/assets/a348d316-8e0c-446f-8131-b19c3529811a)

### Mobile View
![Mobile View](https://github.com/user-attachments/assets/bcdc47a8-2f27-4778-bb80-21d1aa507ca6)


## Testing
- Tested on both desktop and mobile screen sizes.
- Verified the modal displays the correct email and functions as expected.

---

Please review the component and provide any feedback.
