### PR TITLE
refactor: change button variant for signIn and signUp for google and …

### DIFF
--- a/src/features/auth/api/auth.types.ts
+++ b/src/features/auth/api/auth.types.ts
@@ -27,8 +27,8 @@ export type ErrorResponse = {
   data: {
     /** A general error message or error type */
     error: string
-    /** An array of specific error messages for different fields */
-    messages: { field: string; message: string }[]
+    /** An array of specific error messages for different fields or a single string message */
+    messages: { field: string; message: string }[] | string
     /** The HTTP status code of the error */
     statusCode: number
   }

--- a/src/features/auth/ui/authCard/authCard.tsx
+++ b/src/features/auth/ui/authCard/authCard.tsx
@@ -49,13 +49,13 @@ export const AuthCard = ({
       <div className={classNames.header}>
         <Typography variant={'h1'}>{title}</Typography>
         <div className={classNames.links}>
-          <Button asChild variant={'link'}>
+          <Button asChild variant={'icon-link'}>
             {/**TODO: add link to google*/}
             <Link href={'#'} passHref>
               <GoogleSvgrepoCom1 className={classNames.icons} />
             </Link>
           </Button>
-          <Button asChild variant={'link'}>
+          <Button asChild variant={'icon-link'}>
             {/**TODO: add link to github*/}
             <Link href={'#'} passHref>
               <GithubSvgrepoCom31 className={classNames.icons} />

--- a/src/features/auth/ui/createNewPassword/useCreateNewPassword.ts
+++ b/src/features/auth/ui/createNewPassword/useCreateNewPassword.ts
@@ -76,6 +76,7 @@ export const useCreateNewPassword = () => {
       handleErrorResponse({
         badRequestSchema,
         error,
+        isToast: true,
         setError,
       })
     }

--- a/src/features/auth/ui/signIn/signIn.tsx
+++ b/src/features/auth/ui/signIn/signIn.tsx
@@ -21,7 +21,7 @@ import { FormInputs, useSignIn } from './useSignIn'
  */
 
 export const SignIn = () => {
-  const { control, errors, handleSubmit } = useSignIn()
+  const { control, errors, onSubmit } = useSignIn()
   const classNames = {
     container: styles.container,
     form: styles.form,
@@ -34,7 +34,7 @@ export const SignIn = () => {
       footerText={"Don't have an account?"}
       title={'Sign In'}
     >
-      <form className={classNames.form} onSubmit={handleSubmit}>
+      <form className={classNames.form} onSubmit={onSubmit}>
         <div className={classNames.container}>
           <Controller
             control={control}

--- a/src/features/auth/ui/signIn/useSignIn.ts
+++ b/src/features/auth/ui/signIn/useSignIn.ts
@@ -2,8 +2,8 @@ import { useForm } from 'react-hook-form'
 
 import { SuccessSignInResponse, useSignInMutation } from '@/features'
 import { PASSWORD_REGEX } from '@/shared/config'
+import { handleErrorResponse } from '@/shared/utils'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { FetchBaseQueryError } from '@reduxjs/toolkit/query'
 import { useRouter } from 'next/router'
 import { z } from 'zod'
 
@@ -15,6 +15,15 @@ const signInSchema = z.object({
     .min(6, 'Password must be at least 6 characters')
     .max(20, 'Password must be at most 20 characters')
     .regex(PASSWORD_REGEX),
+})
+
+const badRequestSchema = z.object({
+  messages: z.array(
+    z.object({
+      field: z.enum(['email', 'password']),
+      message: z.string(),
+    })
+  ),
 })
 
 export const useSignIn = () => {
@@ -35,7 +44,7 @@ export const useSignIn = () => {
   })
   const [signIn] = useSignInMutation()
 
-  const onSubmitForm = async (data: FormInputs) => {
+  const onSubmit = handleSubmit(async (data: FormInputs) => {
     clearErrors()
     try {
       const response = (await signIn(data).unwrap()) as unknown as SuccessSignInResponse
@@ -44,45 +53,18 @@ export const useSignIn = () => {
       localStorage.setItem('signInToken', response.accessToken)
       // TODO: add redirect to home page and use routing constants
       router.push('/home')
-    } catch (err) {
-      if (isFetchBaseQueryError(err)) {
-        const error = err as FetchBaseQueryError
-
-        if (error.status === 400) {
-          {
-            /**TODO: check response data and add error message*/
-          }
-          setError('email', {
-            //TODO:temporary solution to add error message
-            // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-            //@ts-expect-error
-            message: error.data.messages ?? 'Incorrect input data',
-            type: 'manual',
-          })
-        } else if (error.status === 401) {
-          setError('email', { message: 'Unauthorized', type: 'manual' })
-        } else if (error.status === 429) {
-          setError('email', {
-            message: 'More than 5 attempts from one IP-address during 10 seconds',
-            type: 'manual',
-          })
-        } else {
-          setError('email', { message: 'An error occurred. Please try again.', type: 'manual' })
-        }
-      } else {
-        setError('email', { message: 'An unexpected error occurred.', type: 'manual' })
-      }
-      console.error('Login failed', err)
+    } catch (error: unknown) {
+      handleErrorResponse<FormInputs>({
+        badRequestSchema,
+        error,
+        setError,
+      })
     }
-  }
+  })
 
   return {
     control,
     errors,
-    handleSubmit: handleSubmit(onSubmitForm),
+    onSubmit,
   }
-}
-
-function isFetchBaseQueryError(error: unknown): error is FetchBaseQueryError {
-  return typeof error === 'object' && error != null && 'status' in error
 }

--- a/src/features/auth/ui/signUp/signUp.tsx
+++ b/src/features/auth/ui/signUp/signUp.tsx
@@ -30,13 +30,13 @@ export const SignUp = () => {
           Sign Up
         </Typography>
         <span className={classNames.iconsBox}>
-          <Button asChild type={'button'} variant={'link'}>
+          <Button asChild type={'button'} variant={'icon-link'}>
             {/*TODO: check path for links*/}
             <Link href={'#'}>
               <GoogleSvgrepoCom1 className={classNames.icon} />
             </Link>
           </Button>
-          <Button asChild type={'button'} variant={'link'}>
+          <Button asChild type={'button'} variant={'icon-link'}>
             {/*TODO: check path for links*/}
             <Link href={'#'}>
               <GithubSvgrepoCom31 className={classNames.icon} />

--- a/src/features/auth/ui/signUp/useSignUpForm.tsx
+++ b/src/features/auth/ui/signUp/useSignUpForm.tsx
@@ -4,6 +4,7 @@ import { toast } from 'react-toastify'
 
 import { useSignUpMutation } from '@/features'
 import { PASSWORD_REGEX, USERNAME_REGEX } from '@/shared/config'
+import { handleErrorResponse } from '@/shared/utils'
 import { zodResolver } from '@hookform/resolvers/zod'
 import { z } from 'zod'
 
@@ -77,20 +78,8 @@ export const useSignUpForm = () => {
         setIsOpen(true)
         reset()
       })
-      .catch(e => {
-        const parsed = badRequestSchema.safeParse(e.data)
-
-        if (parsed.success) {
-          parsed.data.messages.forEach(m => setError(m.field, { message: m.message }))
-        } else if ('error' in e) {
-          toast.error(e.error)
-        } else if ('message' in e) {
-          toast.error(e.message)
-        } else {
-          const message = JSON.stringify(e) ?? 'Some error'
-
-          toast.error(message)
-        }
+      .catch(error => {
+        handleErrorResponse<FormValues>({ badRequestSchema, error, setError })
       })
   })
 

--- a/src/shared/utils/isValidErrorResponse.ts
+++ b/src/shared/utils/isValidErrorResponse.ts
@@ -6,13 +6,16 @@ import { ErrorResponse } from '@/features/auth'
  * if (isValidErrorResponse(error)) {
  *   console.log(error.data.statusCode);
  *   console.log(`Error message: ${error.data.error}`);
- *   error.data.messages.forEach(msg => {
+ *   if (Array.isArray(error.data.messages)) {
+ *     error.data.messages.forEach(msg => {
  *       console.log(`Field: ${msg.field}, Message: ${msg.message}`);
  *     });
- * }
- * else {
- *  console.log('Unexpected error structure:', error);
+ *   } else {
+ *     console.log(`Message: ${error.data.messages}`);
  *   }
+ * } else {
+ *   console.log('Unexpected error structure:', error);
+ * }
  */
 export function isValidErrorResponse(error: unknown): error is ErrorResponse {
   if (
@@ -27,16 +30,17 @@ export function isValidErrorResponse(error: unknown): error is ErrorResponse {
       'error' in data &&
       typeof data.error === 'string' &&
       'messages' in data &&
-      Array.isArray(data.messages) &&
-      data.messages.every(
-        msg =>
-          typeof msg === 'object' &&
-          msg !== null &&
-          'field' in msg &&
-          typeof msg.field === 'string' &&
-          'message' in msg &&
-          typeof msg.message === 'string'
-      ) &&
+      (Array.isArray(data.messages)
+        ? data.messages.every(
+            msg =>
+              typeof msg === 'object' &&
+              msg !== null &&
+              'field' in msg &&
+              typeof msg.field === 'string' &&
+              'message' in msg &&
+              typeof msg.message === 'string'
+          )
+        : typeof data.messages === 'string') &&
       'statusCode' in data &&
       typeof data.statusCode === 'number'
     )


### PR DESCRIPTION
# Refactor Sign In and Sign Up Components

## Changes

1. Changed button variant for Google and GitHub sign-in/sign-up options
2. Updated error handling for sign-in and sign-up processes
3. Improved `handleErrorResponse` and `isValidErrorResponse` functions
4. Updated `ErrorResponse` type in `auth.types.ts`

## Details

### Button Variant Changes

- Modified the variant of Google and GitHub authentication buttons from [old variant] to [new variant] for better visual consistency and user experience.

### Error Handling Updates

- Implemented more robust error handling in sign-in and sign-up processes.
- Now catching and properly displaying specific error messages from the backend.

### handleErrorResponse and isValidErrorResponse

- Refactored `handleErrorResponse` to handle both array and string message formats.
- Added an optional `isToast` parameter to control toast notifications.
- Updated `isValidErrorResponse` to accurately check the structure of error responses.

### ErrorResponse Type Update

- Modified `ErrorResponse` type in `auth.types.ts` to accommodate both array and string formats for error messages.

## Testing

- Manually tested sign-in and sign-up flows with various error scenarios.
- Verified correct display of error messages in forms and toast notifications.

## Notes

- This refactor improves error handling and provides more flexibility in how errors are displayed to users.
- The changes to button variants enhance the visual consistency of the authentication UI.

Please review and provide feedback, especially on the error handling logic and UI changes.