### PR TITLE
add logout function

### DIFF
--- a/src/features/auth/api/authApi.ts
+++ b/src/features/auth/api/authApi.ts
@@ -39,6 +39,14 @@ export const authApi = baseApi.injectEndpoints({
           url: API_URLS.AUTH.NEW_PASSWORD,
         }),
       }),
+      logout: builder.mutation<void, void>({
+        invalidatesTags: ['Auth'],
+        query: params => ({
+          body: params,
+          method: 'POST',
+          url: 'v1/auth/logout',
+        }),
+      }),
       passwordRecovery: builder.mutation<void, PasswordRecoveryData>({
         query: params => ({
           body: params,
@@ -93,6 +101,7 @@ export const {
   useConfirmRegistrationQuery,
   useCreateNewPasswordMutation,
   useLazyAuthMeQuery,
+  useLogoutMutation,
   usePasswordRecoveryMutation,
   useResendLinkMutation,
   useSignInMutation,

--- a/src/features/auth/ui/logout/logoutModal/logoutModal.module.scss
+++ b/src/features/auth/ui/logout/logoutModal/logoutModal.module.scss
@@ -1,0 +1,66 @@
+@use '@/app/styles/mixins' as *;
+
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: 0 24px 36px;
+
+  @include mobile {
+    padding: 0 12px 30px;
+  }
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  margin-bottom: 30px;
+  padding: 0 24px;
+
+  @include mobile {
+    padding: 12px;
+  }
+}
+
+.content {
+  width: 100%;
+  max-width: 380px;
+
+  @include mobile {
+    max-width: 330px;
+  }
+}
+
+.footer {
+  display: flex;
+  justify-content: end;
+
+  button {
+    @include mobile {
+      width: 100%;
+      padding: 12px 0;
+    }
+  }
+}
+
+.description {
+  @include mobile {
+    max-width: 306px;
+    margin: 0 auto;
+    text-align: center;
+  }
+}
+
+.icon {
+  cursor: pointer;
+  width: var(--svg-size);
+  height: var(--svg-size);
+
+  &:hover {
+    color: var(--light-900);
+  }
+
+  &:active {
+    color: var(--light-100);
+  }
+}

--- a/src/features/auth/ui/logout/logoutModal/logoutModal.tsx
+++ b/src/features/auth/ui/logout/logoutModal/logoutModal.tsx
@@ -1,0 +1,57 @@
+import { CloseOutline } from '@/shared/assets'
+import {
+  Button,
+  Modal,
+  ModalClose,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+  Typography,
+} from '@photo-fiesta/ui-lib'
+
+import styles from './logoutModal.module.scss'
+export type LogoutModalProps = {
+  closeModal: () => void
+  confirmLogout: () => void
+  open: boolean
+}
+
+export const LogoutModal = ({ closeModal, confirmLogout, open }: LogoutModalProps) => {
+  const classNames = {
+    container: styles.container,
+    content: styles.content,
+    description: styles.description,
+    footer: styles.footer,
+    header: styles.header,
+    icon: styles.icon,
+  } as const
+
+  return (
+    <Modal onOpenChange={closeModal} open={open}>
+      <ModalContent className={classNames.content}>
+        <ModalHeader className={classNames.header}>
+          <ModalTitle>
+            <Typography variant={'h1'}>Log Out</Typography>
+          </ModalTitle>
+          <ModalClose onClick={closeModal}>
+            <CloseOutline className={classNames.icon} />
+          </ModalClose>
+        </ModalHeader>
+        <div className={classNames.container}>
+          <Typography className={classNames.description} variant={'text16'}>
+            Are you really want to logout of your account?
+          </Typography>
+          <ModalFooter className={classNames.footer}>
+            <Button onClick={closeModal} variant={'secondary'}>
+              No
+            </Button>
+            <Button onClick={confirmLogout} variant={'primary'}>
+              Yes
+            </Button>
+          </ModalFooter>
+        </div>
+      </ModalContent>
+    </Modal>
+  )
+}

--- a/src/features/auth/ui/logout/useLogout.tsx
+++ b/src/features/auth/ui/logout/useLogout.tsx
@@ -1,0 +1,17 @@
+import { useDispatch } from 'react-redux'
+
+import { baseApi } from '@/app/api'
+import { Storage } from '@/shared/utils/storage'
+import { useRouter } from 'next/router'
+
+export const useLogout = () => {
+  const router = useRouter()
+  const dispatch = useDispatch()
+
+  return () => {
+    Storage.deleteToken()
+    dispatch(baseApi.util.invalidateTags(['Auth']))
+    dispatch(baseApi.util.resetApiState())
+    router.push('/auth/signInPage')
+  }
+}

--- a/src/shared/ui/sidebar/sidebar.tsx
+++ b/src/shared/ui/sidebar/sidebar.tsx
@@ -1,3 +1,7 @@
+import { useState } from 'react'
+
+import { LogoutModal } from '@/features/auth/ui/logout/logoutModal/logoutModal'
+import { useLogout } from '@/features/auth/ui/logout/useLogout'
 import {
   BookmarkOutline,
   HomeOutline,
@@ -14,6 +18,18 @@ import Link from 'next/link'
 import styles from './sidebar.module.scss'
 
 export const Sidebar = () => {
+  const [isModalOpen, setModalOpen] = useState(false)
+  const logout = useLogout()
+
+  const confirmLogout = () => {
+    logout()
+    setModalOpen(false)
+  }
+
+  const closeModal = () => {
+    setModalOpen(false)
+  }
+
   return (
     <div>
       <Sidebars>
@@ -64,12 +80,15 @@ export const Sidebar = () => {
           </Link>
         </div>
         <div className={styles.icons}>
-          <SidebarsElement>
+          <SidebarsElement onClick={() => setModalOpen(true)}>
             <LogOut />
             Log Out
           </SidebarsElement>
         </div>
       </Sidebars>
+      {isModalOpen && (
+        <LogoutModal closeModal={closeModal} confirmLogout={confirmLogout} open={isModalOpen} />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
This PR implements the Logout functionality and adds a Logout confirmation modal. The functionality includes:

### **useLogout Hook:**

Handles the logout process by:
Removing the authentication token from local storage.
Redirecting the user to the Sign In page (/auth/signInPage).
Resetting or invalidating the RTK Query cache to clear the user's session data.

### **LogoutModal Component:**

A confirmation modal that is triggered when the user clicks on the "Logout" button.
The modal prompts the user to confirm whether they want to log out of the application.
If the user confirms, the useLogout hook is triggered, logging the user out and redirecting them to the Sign In page.
If the user cancels, they remain on the current page.

### **Changes:**

Added the useLogout hook to handle the full logout flow.
Created the LogoutModal component to provide a smooth UX for logging out.
Integrated the modal into the sidebar’s logout button.