### PR TITLE
feature/PROJ-186.1: add MobilePopover component

### DIFF
--- a/src/shared/config/locales/en.ts
+++ b/src/shared/config/locales/en.ts
@@ -3,6 +3,7 @@ export const en = {
     backToSignIn: 'Back to Sign In',
     backToSignUp: 'Back to Sign Up',
     confirm: 'Confirm password',
+    confirmLogout: 'Are you really want to logout of your account?',
     confirmPassword: 'Password confirmation',
     congratulations: 'Congratulations!',
     createNewPassword: 'Create new password',

--- a/src/shared/config/locales/ru.ts
+++ b/src/shared/config/locales/ru.ts
@@ -5,6 +5,7 @@ export const ru: LocaleType = {
     backToSignIn: 'Вернуться к входу',
     backToSignUp: 'Вернуться к регистрации',
     confirm: 'Повторите пароль',
+    confirmLogout: 'Вы действительно хотите выйти из вашего аккаунта?',
     confirmPassword: 'Подтверждение пароля',
     congratulations: 'Поздравляем!',
     createNewPassword: 'Создание нового пароля',

--- a/src/widgets/header/header.module.scss
+++ b/src/widgets/header/header.module.scss
@@ -77,11 +77,3 @@
     display: none;
   }
 }
-
-.more {
-  display: none;
-
-  @include mobile {
-    display: block;
-  }
-}

--- a/src/widgets/header/header.tsx
+++ b/src/widgets/header/header.tsx
@@ -1,8 +1,9 @@
 import { ComponentPropsWithoutRef, ElementRef, forwardRef } from 'react'
 
-import { MoreHorizontal, OutlineBell } from '@/shared/assets'
+import { OutlineBell } from '@/shared/assets'
 import { ROUTES } from '@/shared/config'
 import { LanguageSelect } from '@/shared/ui'
+import { MobilePopover } from '@/widgets'
 import { Button, Typography } from '@photo-fiesta/ui-lib'
 import clsx from 'clsx'
 import Link from 'next/link'
@@ -46,7 +47,7 @@ export const Header = forwardRef<ElementRef<'div'>, HeaderProps>(
           {isAuth && <OutlineBell className={classNames.bell} />}
           <LanguageSelect className={classNames.select} />
           {/**TODO: add dropdown menu using icon for mobile*/}
-          {isAuth && <MoreHorizontal className={classNames.more} />}
+          {isAuth && <MobilePopover />}
           {!isAuth && (
             <div className={classNames.loginButtons}>
               <Button asChild variant={'link'}>

--- a/src/widgets/index.ts
+++ b/src/widgets/index.ts
@@ -1,5 +1,6 @@
 export * from './header'
 export * from './layout'
+export * from './mobilePopover'
 export * from './modals'
 export * from './sidebar'
 export * from './slider'

--- a/src/widgets/mobilePopover/index.ts
+++ b/src/widgets/mobilePopover/index.ts
@@ -1,0 +1,1 @@
+export * from './mobilePopover'

--- a/src/widgets/mobilePopover/mobilePopover.module.scss
+++ b/src/widgets/mobilePopover/mobilePopover.module.scss
@@ -1,0 +1,25 @@
+@use '@/app/styles/mixins' as *;
+
+.more {
+  display: none;
+
+  @include mobile {
+    display: block;
+  }
+
+  &[data-state='closed'] {
+    color: inherit;
+  }
+}
+
+.popoverContent {
+  z-index: 1;
+  gap: 24px;
+  max-width: 260px;
+  padding-block: 18px;
+
+  & a {
+    color: inherit;
+    text-decoration: none;
+  }
+}

--- a/src/widgets/mobilePopover/mobilePopover.module.scss
+++ b/src/widgets/mobilePopover/mobilePopover.module.scss
@@ -13,7 +13,7 @@
 }
 
 .popoverContent {
-  z-index: 1;
+  z-index: 100;
   gap: 24px;
   max-width: 260px;
   padding-block: 18px;

--- a/src/widgets/mobilePopover/mobilePopover.tsx
+++ b/src/widgets/mobilePopover/mobilePopover.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react'
+
+import { useProfile } from '@/features'
+import { LogOut, MoreHorizontal, SettingsOutline } from '@/shared/assets'
+import { ROUTES } from '@/shared/config'
+import { PopoverContent, PopoverRoot, PopoverTrigger } from '@/shared/ui'
+import { useTranslation } from '@/shared/utils'
+import { ConfirmationModal, SidebarElement } from '@/widgets'
+import { useSidebar } from '@/widgets/sidebar/useSidebar'
+
+import styles from './mobilePopover.module.scss'
+
+/**
+ * MobilePopover component for rendering a popover menu specifically for mobile view,
+ * This component provides access to profile settings, statics, favorites and logout functionality.
+ */
+export const MobilePopover = () => {
+  const [openPopover, setOpenPopover] = useState(false)
+
+  const { confirmLogout, handleCloseLogoutModal, handleLogoutClick, modalState, sidebarItems } =
+    useSidebar()
+
+  const { isModalOpen } = modalState
+
+  const { t } = useTranslation()
+
+  const { handleProfileSettings } = useProfile()
+
+  const renderProfileSettings = (
+    <SidebarElement
+      icon={SettingsOutline}
+      isActive={() => ''}
+      onClick={() => {
+        handleProfileSettings()
+        setOpenPopover(false)
+      }}
+      text={t.myProfile.settings}
+    />
+  )
+
+  const renderRestItems = sidebarItems
+    .filter(item => item.href === ROUTES.STATICS || item.href === ROUTES.FAVORITES)
+    .map(item => (
+      <SidebarElement
+        href={item.href}
+        icon={item.icon}
+        isActive={() => ''}
+        key={item.href}
+        onClick={() => {
+          item.onClick
+          setOpenPopover(false)
+        }}
+        text={item.text}
+      />
+    ))
+
+  const renderLogOut = (
+    <SidebarElement
+      icon={LogOut}
+      isActive={() => ''}
+      onClick={handleLogoutClick}
+      text={t.sidebar.logout}
+    />
+  )
+
+  const classNames = {
+    more: styles.more,
+    popoverContent: styles.popoverContent,
+  } as const
+
+  return (
+    <>
+      <PopoverRoot onOpenChange={setOpenPopover} open={openPopover}>
+        <PopoverTrigger asChild>
+          <MoreHorizontal
+            className={classNames.more}
+            onClick={() => setOpenPopover(!openPopover)}
+          />
+        </PopoverTrigger>
+        <PopoverContent className={classNames.popoverContent}>
+          {renderProfileSettings}
+          {renderRestItems}
+          {renderLogOut}
+        </PopoverContent>
+      </PopoverRoot>
+      {isModalOpen && (
+        <ConfirmationModal
+          closeModal={handleCloseLogoutModal}
+          confirmation={confirmLogout}
+          content={'Are you really want to logout of your account?'}
+          isOpen={isModalOpen}
+          title={t.sidebar.logout}
+        />
+      )}
+    </>
+  )
+}

--- a/src/widgets/mobilePopover/mobilePopover.tsx
+++ b/src/widgets/mobilePopover/mobilePopover.tsx
@@ -26,14 +26,16 @@ export const MobilePopover = () => {
 
   const { handleProfileSettings } = useProfile()
 
+  const profileSettingsOnClickHandler = () => {
+    handleProfileSettings()
+    setOpenPopover(false)
+  }
+
   const renderProfileSettings = (
     <SidebarElement
       icon={SettingsOutline}
       isActive={() => ''}
-      onClick={() => {
-        handleProfileSettings()
-        setOpenPopover(false)
-      }}
+      onClick={profileSettingsOnClickHandler}
       text={t.myProfile.settings}
     />
   )

--- a/src/widgets/mobilePopover/mobilePopover.tsx
+++ b/src/widgets/mobilePopover/mobilePopover.tsx
@@ -87,7 +87,7 @@ export const MobilePopover = () => {
         <ConfirmationModal
           closeModal={handleCloseLogoutModal}
           confirmation={confirmLogout}
-          content={'Are you really want to logout of your account?'}
+          content={t.auth.confirmLogout}
           isOpen={isModalOpen}
           title={t.sidebar.logout}
         />

--- a/src/widgets/mobilePopover/mobilePopover.tsx
+++ b/src/widgets/mobilePopover/mobilePopover.tsx
@@ -39,7 +39,7 @@ export const MobilePopover = () => {
   )
 
   const renderRestItems = sidebarItems
-    .filter(item => item.href === ROUTES.STATICS || item.href === ROUTES.FAVORITES)
+    .filter(item => item.href.startsWith(ROUTES.STATICS) || item.href.startsWith(ROUTES.FAVORITES))
     .map(item => (
       <SidebarElement
         href={item.href}

--- a/src/widgets/sidebar/sidebar.tsx
+++ b/src/widgets/sidebar/sidebar.tsx
@@ -123,7 +123,7 @@ type SidebarElementProps = {
  * It's used for both navigation items and the logout button in the sidebar.
  *
  */
-const SidebarElement = ({
+export const SidebarElement = ({
   href,
   icon: Icon,
   isActive,


### PR DESCRIPTION
# Description

This PR introduces the MobilePopover component, a popover menu designed for mobile view, which provides users with easy access to essential profile settings, statics, favorites and a logout option

<img width="221" alt="image" src="https://github.com/user-attachments/assets/40e70ca8-633c-4dc2-833b-3e7161acea4c">


