### PR TITLE
bug/PROJ-216: fix Profile Settings on desktop view

### DIFF
--- a/src/features/profile/ui/settings/settings.module.scss
+++ b/src/features/profile/ui/settings/settings.module.scss
@@ -21,12 +21,21 @@
 }
 
 .profileSettings {
+  display: none;
+  @include mobile {
+    display: block;
   text-align: center;
+  }
 }
 
 .linkMyProfileRoute {
-  position: absolute;
-  height: 24px;
+  display: none;
+  @include mobile {
+    display: block;
+    position: absolute;
+    height: 24px;
+  }
+
 }
 
 .tabsContainer {

--- a/src/features/profile/ui/settings/settings.module.scss
+++ b/src/features/profile/ui/settings/settings.module.scss
@@ -22,20 +22,21 @@
 
 .profileSettings {
   display: none;
+
   @include mobile {
     display: block;
-  text-align: center;
+    text-align: center;
   }
 }
 
 .linkMyProfileRoute {
   display: none;
+
   @include mobile {
-    display: block;
     position: absolute;
+    display: block;
     height: 24px;
   }
-
 }
 
 .tabsContainer {


### PR DESCRIPTION
# Overview
This pull request removes the **Profile Settings** text, as well as **ArrowBackOutline** icon, from the desktop view, as it was previously styled only for mobile view,.

# Changes
- updated styles in the **Settings** component 

<img width="942" alt="Screenshot 2024-11-05 at 16 03 31" src="https://github.com/user-attachments/assets/87f61bfc-8d50-4912-b96c-cfe260aa32ef">
